### PR TITLE
User router bugfix 1

### DIFF
--- a/src/user/user-router.js
+++ b/src/user/user-router.js
@@ -43,14 +43,12 @@ userRouter
         newUser
       )
 
-      await UserService.populateUserWords(
-        req.app.get('db'),
-        user.id
-      )
 
       res
         .status(201)
-        .location(path.posix.join(req.originalUrl, `/${user.id}`))
+        // Temporarily commenting this out. I don't think we'll have a /users/1 endpoint in the frontend anyway
+        // .location(path.posix.join(req.originalUrl, `/${user.id}`))j
+        // Also for below, do we need to send a user back?
         .json(UserService.serializeUser(user))
     } catch(error) {
       next(error)


### PR DESCRIPTION
Removed mention of the "words" service method. 

Also, left a comment about returning a location. Are we planning on the front-end to have a /users/:id endpoint? If not, we can also remove the location line from the return